### PR TITLE
ML-362 Fixed error in import statement

### DIFF
--- a/Bundle.ecl
+++ b/Bundle.ecl
@@ -6,6 +6,6 @@ EXPORT Bundle := MODULE(Std.BundleBase)
  EXPORT License := 'http://www.apache.org/licenses/LICENSE-2.0';
  EXPORT Copyright := 'Copyright (C) 2016, 2017 HPCC Systems';
  EXPORT DependsOn := ['ML_Core'];
- EXPORT Version := '3.0.1';
+ EXPORT Version := '3.0.2';
  EXPORT PlatformVersion := '6.2.0';
 END;

--- a/ecl/ConfTest.ecl
+++ b/ecl/ConfTest.ecl
@@ -18,7 +18,7 @@ IMPORT PBblas.MatUtils;
 IMPORT PBblas.Types;
 IMPORT int.Types as iTypes;
 IMPORT Std.BLAS;
-IMPORT ^.test as Tests;
+IMPORT $.^.test as Tests;
 IMPORT Tests.MakeTestMatrix as tm;
 
 matrix_t := iTypes.matrix_t;


### PR DESCRIPTION
The import was{code}IMPORT ^.test as Tests;{code} which is clearly wrong.  The path should have been $.^ instead.

Bundle version updated.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>